### PR TITLE
Logging Fallback

### DIFF
--- a/microcosm_sagemaker/metrics/store.py
+++ b/microcosm_sagemaker/metrics/store.py
@@ -41,7 +41,7 @@ class SageMakerMetrics(object):
                 Namespace="/aws/sagemaker/" + model_name,
                 MetricData=metric_data,
             )
-        except ClientError, NoCredentialsError, NoRegionError:
+        except (ClientError, NoCredentialsError, NoRegionError):
             info("CloudWatch publishing disabled")
             info(dumps(metric_data, indent=4))
             response = None


### PR DESCRIPTION
On remote instances without a default boto3 credential provided, the store initialization will fail due to a NoRegionError or a NoCredentialError.  This PR provides fallback handling to log these metrics locally instead.