### PR TITLE
Bring loader back

### DIFF
--- a/microcosm_sagemaker/app_hooks.py
+++ b/microcosm_sagemaker/app_hooks.py
@@ -12,18 +12,18 @@ from microcosm_sagemaker.exceptions import AppHookNotFoundError
 
 
 def create_train_app(*args, **kwargs) -> ObjectGraph:
-    return _create_app(TRAIN_APP_HOOK, args, kwargs)
+    return _create_app(TRAIN_APP_HOOK, *args, **kwargs)
 
 
 def create_serve_app(*args, **kwargs) -> ObjectGraph:
-    return _create_app(SERVE_APP_HOOK, args, kwargs)
+    return _create_app(SERVE_APP_HOOK, *args, **kwargs)
 
 
 def create_evaluate_app(*args, **kwargs) -> ObjectGraph:
-    return _create_app(EVALUATE_APP_HOOK, args, kwargs)
+    return _create_app(EVALUATE_APP_HOOK, *args, **kwargs)
 
 
-def _create_app(name: str, args: tuple, kwargs: dict) -> ObjectGraph:
+def _create_app(name: str, *args: tuple, **kwargs: dict) -> ObjectGraph:
     try:
         entry_point = next(
             entry_point

--- a/microcosm_sagemaker/loaders.py
+++ b/microcosm_sagemaker/loaders.py
@@ -3,6 +3,7 @@ Loaders to inject SM parameters as microcosm configurations.
 
 """
 import json
+from os.path import join
 
 from boto3 import client
 from microcosm.config.model import Configuration
@@ -10,7 +11,7 @@ from microcosm.loaders.compose import merge
 from microcosm.loaders.keys import expand_config
 from microcosm.metadata import Metadata
 
-from microcosm_sagemaker.constants import SagemakerPath
+from microcosm_sagemaker.constants import ARTIFACT_CONFIGURATION_PATH, SagemakerPath
 from microcosm_sagemaker.s3 import S3Object
 
 
@@ -73,3 +74,17 @@ def load_train_conventions(metadata: Metadata) -> Configuration:
         ])
 
     return configuration
+
+
+def load_model_artifact_config(artifact_path):
+    """
+    When we train a model, we freeze all of the current graph variables and store it alongside
+    the artifact. Whenever we boot up the model again, we want to hydrate this from disk.
+    """
+    def _load_path(metadata):
+        path = join(artifact_path, ARTIFACT_CONFIGURATION_PATH)
+
+        with open(path) as raw_file:
+            return json.load(raw_file)
+
+    return _load_path


### PR DESCRIPTION
**Why?**
We still have two repos that expect this loader to exist (see [here](https://github.com/globality-corp/ml-taxonomysimilarity-classifier/blob/master/ml_taxonomysimilarity_classifier/serve/app.py#L14) and [there](https://github.com/globality-corp/ml-projectcasesimilarity-classifier/blob/research/ml_projectcasesimilarity_classifier/serve/app.py#L7)).

The loader was removed 12 days ago (see [here](https://github.com/globality-corp/microcosm-sagemaker/commit/34842f3c5370e77563ba77754cff0ab5010dd914#diff-8297421ea6c828cf7c61dc2102ce6635L78)). Bringing back - if we should instead remove it from other repos, let's still bring it back first then remove it once no repo depend on it.

**Also:**
Fix method signature