### PR TITLE
Add artifact subdir

### DIFF
--- a/microcosm_sagemaker/artifact.py
+++ b/microcosm_sagemaker/artifact.py
@@ -15,6 +15,14 @@ class OutputArtifact:
     def init(self) -> None:
         self.path.mkdir(parents=True, exist_ok=True)
 
+    def __truediv__(self, name: str):
+        return OutputArtifact(self.path / name)
+
+
+class RootOutputArtifact(OutputArtifact):
+    def __init__(self, path: Union[str, Path]):
+        super().__init__(path)
+
     def save_config(self, config: Configuration) -> None:
         config_path = self.path / ARTIFACT_CONFIGURATION_PATH
 
@@ -25,6 +33,14 @@ class OutputArtifact:
 class InputArtifact:
     def __init__(self, path: Union[str, Path]):
         self.path = Path(path)
+
+    def __truediv__(self, name: str):
+        return InputArtifact(self.path / name)
+
+
+class RootInputArtifact(InputArtifact):
+    def __init__(self, path: Union[str, Path]):
+        super().__init__(path)
 
     def load_config(self, metadata: Metadata) -> Configuration:
         """

--- a/microcosm_sagemaker/commands/evaluate.py
+++ b/microcosm_sagemaker/commands/evaluate.py
@@ -6,7 +6,7 @@ from click import command
 from microcosm.object_graph import ObjectGraph
 
 from microcosm_sagemaker.app_hooks import create_evaluate_app
-from microcosm_sagemaker.artifact import InputArtifact
+from microcosm_sagemaker.artifact import RootInputArtifact
 from microcosm_sagemaker.commands.options import input_artifact_option, input_data_option
 from microcosm_sagemaker.input_data import InputData
 
@@ -25,10 +25,11 @@ def main(input_data, input_artifact):
 def run_evaluate(
     graph: ObjectGraph,
     input_data: InputData,
-    input_artifact: InputArtifact,
+    input_artifact: RootInputArtifact,
 ) -> None:
     # Load the saved artifact
-    graph.active_bundle.load(input_artifact)
+    active_bundle_input_artifact = input_artifact / graph.config.active_bundle
+    graph.active_bundle.load(active_bundle_input_artifact)
 
     # Evaluate
     graph.active_evaluation(graph.active_bundle, input_data)

--- a/microcosm_sagemaker/commands/options.py
+++ b/microcosm_sagemaker/commands/options.py
@@ -1,6 +1,6 @@
 from click import Path, option
 
-from microcosm_sagemaker.artifact import InputArtifact, OutputArtifact
+from microcosm_sagemaker.artifact import RootInputArtifact, RootOutputArtifact
 from microcosm_sagemaker.constants import SagemakerPath
 from microcosm_sagemaker.input_data import InputData
 
@@ -27,7 +27,7 @@ def input_artifact_option():
             file_okay=False,
             exists=True,
         ),
-        callback=_make_click_callback(InputArtifact),
+        callback=_make_click_callback(RootInputArtifact),
         default=SagemakerPath.MODEL,
         help="Path from which to load artifact",
     )
@@ -41,7 +41,7 @@ def output_artifact_option():
             file_okay=False,
             writable=True,
         ),
-        callback=_make_click_callback(OutputArtifact),
+        callback=_make_click_callback(RootOutputArtifact),
         default=SagemakerPath.MODEL,
         help="Path for outputting trained artifact",
     )

--- a/microcosm_sagemaker/commands/runserver.py
+++ b/microcosm_sagemaker/commands/runserver.py
@@ -44,7 +44,8 @@ def run_serve(
         host: str,
         port: int,
 ) -> None:
-    graph.active_bundle.load(input_artifact)
+    active_bundle_input_artifact = input_artifact / graph.config.active_bundle
+    graph.active_bundle.load(active_bundle_input_artifact)
 
     graph.flask.run(
         host=host,

--- a/microcosm_sagemaker/commands/train.py
+++ b/microcosm_sagemaker/commands/train.py
@@ -8,7 +8,7 @@ from click import File, command, option
 from microcosm.object_graph import ObjectGraph
 
 from microcosm_sagemaker.app_hooks import create_train_app
-from microcosm_sagemaker.artifact import OutputArtifact
+from microcosm_sagemaker.artifact import RootOutputArtifact
 from microcosm_sagemaker.commands.options import input_data_option, output_artifact_option
 from microcosm_sagemaker.exceptions import raise_sagemaker_exception
 from microcosm_sagemaker.input_data import InputData
@@ -44,16 +44,19 @@ def main(configuration, input_data, output_artifact, auto_evaluate):
 def run_train(
     graph: ObjectGraph,
     input_data: InputData,
-    output_artifact: OutputArtifact,
+    output_artifact: RootOutputArtifact,
 ) -> None:
     output_artifact.init()
     output_artifact.save_config(graph.config)
+
+    active_bundle_output_artifact = output_artifact / graph.config.active_bundle
+    active_bundle_output_artifact.init()
 
     graph.training_initializers.init()
 
     bundle = graph.active_bundle
     bundle.fit(input_data)
-    bundle.save(output_artifact)
+    bundle.save(active_bundle_output_artifact)
 
 
 def run_auto_evaluate(graph: ObjectGraph, input_data: InputData) -> None:

--- a/microcosm_sagemaker/decorators.py
+++ b/microcosm_sagemaker/decorators.py
@@ -1,0 +1,19 @@
+from typing import Any, Callable
+
+from microcosm.object_graph import ObjectGraph
+
+
+def training_initializer():
+    """
+    Register a microcosm component as a training initializer, so that its init
+    method will automatically be called.  This function is designed to be used
+    as a decorator on a factory.
+
+    """
+    def decorator(func: Callable[[ObjectGraph], Any]):
+        def factory(graph):
+            component = func(graph)
+            graph.training_initializers.register(component)
+            return component
+        return factory
+    return decorator

--- a/microcosm_sagemaker/random.py
+++ b/microcosm_sagemaker/random.py
@@ -2,15 +2,16 @@ from random import seed
 
 from microcosm.api import defaults
 
+from microcosm_sagemaker.decorators import training_initializer
+
 
 @defaults(
     seed=42,
 )
+@training_initializer()
 class Random:
     def __init__(self, graph):
         self.seed = graph.config.random.seed
-
-        graph.training_initializers.register(self)
 
     def init(self):
         seed(self.seed)

--- a/microcosm_sagemaker/testing/invocations.py
+++ b/microcosm_sagemaker/testing/invocations.py
@@ -16,7 +16,7 @@ from hamcrest import (
 from hamcrest.core.base_matcher import BaseMatcher
 
 from microcosm_sagemaker.app_hooks import create_serve_app
-from microcosm_sagemaker.artifact import InputArtifact
+from microcosm_sagemaker.artifact import RootInputArtifact
 
 
 class InvocationsRouteTestCase:
@@ -25,7 +25,7 @@ class InvocationsRouteTestCase:
 
     """
     def setup(self, input_artifact_path: Path) -> None:
-        self.input_artifact = InputArtifact(input_artifact_path)
+        self.input_artifact = RootInputArtifact(input_artifact_path)
 
         self.graph = create_serve_app(
             testing=True,

--- a/microcosm_sagemaker/testing/invocations.py
+++ b/microcosm_sagemaker/testing/invocations.py
@@ -44,7 +44,8 @@ class InvocationsRouteTestCase:
         `items` entry of the response against `response_items_matcher`.
 
         """
-        self.graph.active_bundle.load(self.input_artifact)
+        active_bundle_input_artifact = self.input_artifact / self.graph.config.active_bundle
+        self.graph.active_bundle.load(active_bundle_input_artifact)
 
         uri = "/invocations"
 


### PR DESCRIPTION
This PR automatically creates a nested directory in the output artifact for the bundle to use.  This way the bundle won't interfere with any files we put at the top level of the output artifact, such as the `configuration.json`