### PR TITLE
Always display local metrics

### DIFF
--- a/microcosm_sagemaker/metrics/store.py
+++ b/microcosm_sagemaker/metrics/store.py
@@ -40,8 +40,8 @@ class SageMakerMetrics:
                 MetricData=metric_data,
             )
         except (ClientError, NoCredentialsError, NoRegionError):
-            info("CloudWatch publishing disabled")
-            info(dumps(metric_data, indent=4))
+            print("CloudWatch publishing disabled")  # noqa: T003
+            print(dumps(metric_data, indent=4))  # noqa: T003
             response = None
 
         return response

--- a/microcosm_sagemaker/metrics/store.py
+++ b/microcosm_sagemaker/metrics/store.py
@@ -1,5 +1,4 @@
 from json import dumps
-from logging import info
 
 from boto3 import client
 from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError


### PR DESCRIPTION
When evaluation is run locally, we won't publish metrics to Sagemaker and instead will print them to the console.  The expected user behavior is to print these to the console - but if their logging settings silence `info` calls, then nothing will be posted.