### PR TITLE
Fix null config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     install_requires=[
         "boto3>=1.9.90",
         "click>=7.0",
-        "microcosm>=2.8.0",
-        "microcosm_flask[metrics,spooky]>=1.20.0",
+        "microcosm>=2.11.0",
+        "microcosm_flask[metrics,spooky]>=1.28.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
We were seeing issues where saving config left `null` values in the json which caused exceptions on rehydrating the config.  This PR bumps versions of `microcosom` and `microcosm-flask` to incorporate fixes.  See [GLOB-34194](https://globality.atlassian.net/browse/GLOB-34194) and [GLOB-34180](https://globality.atlassian.net/browse/GLOB-34180).