### PR TITLE
Feature/add api health support to microcosm sagemaker

### DIFF
--- a/microcosm_sagemaker/conventions/health.py
+++ b/microcosm_sagemaker/conventions/health.py
@@ -1,0 +1,49 @@
+"""
+health controller.
+"""
+from marshmallow import Schema, fields
+from microcosm_flask.conventions.base import Convention
+from microcosm_flask.conventions.encoding import dump_response_data
+from microcosm_flask.conventions.registry import response
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+
+
+class PingSchema(Schema):
+    status = fields.String()
+    name = fields.String()
+    ok = fields.Bool()
+
+
+class SagemakerHealthConvention(Convention):
+    def __init__(self, graph):
+        super(SagemakerHealthConvention, self).__init__(graph)
+
+    def configure_query(self, ns, definition):
+        @self.add_route("/api/health", Operation.Query, ns)
+        # Stephens:
+        #
+        # We need /api/health for AI projects to run on ECS
+        # This is a temp solution untill we complete the migration
+        #
+        # Currently health check exist on /health but not /api/health
+        # because we removed /api from route prefix
+        #
+        # see commands/config.py `build_route_path`
+        #
+        @response(PingSchema())
+        def health_check_query():
+            response_data = dict(
+                name=self.graph.metadata.name,
+                ok=True,
+            )
+            return dump_response_data(PingSchema(), response_data, 200)
+
+
+def configure_health(graph):
+    ns = Namespace(
+        subject="/api/health",
+        version=None
+    )
+    convention = SagemakerHealthConvention(graph)
+    convention.configure(ns, query=tuple())

--- a/microcosm_sagemaker/tests/app_hooks/serve/app.py
+++ b/microcosm_sagemaker/tests/app_hooks/serve/app.py
@@ -55,6 +55,7 @@ def create_app(
         graph.use(
             # SageMaker conventions
             "ping_convention",
+            "sagemaker_health_convention",
 
             # Routes
             "invocations_route",

--- a/microcosm_sagemaker/tests/routes/health/test_crud.py
+++ b/microcosm_sagemaker/tests/routes/health/test_crud.py
@@ -1,0 +1,39 @@
+"""
+Simple CRUD routes tests.
+
+Tests are sunny day cases under the assumption that framework conventions
+handle most error conditions.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries,
+    is_,
+)
+
+from microcosm_sagemaker.testing.route import RouteTestCase
+from microcosm_sagemaker.tests.fixtures import get_fixture_path
+from microcosm_sagemaker.tests.mocks import mock_app_hooks
+
+
+class TestHealthRoute(RouteTestCase):
+    root_input_artifact_path = get_fixture_path("artifact")
+
+    @mock_app_hooks()
+    def setup(self) -> None:
+        super().setup()
+
+    def test_health_check(self) -> None:
+        uri = "/api/health"
+
+        response = self.client.get(uri)
+
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(
+            response.json,
+            has_entries(
+                name="microcosm_sagemaker",
+                ok=True,
+            ),
+        )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
                 "microcosm_sagemaker.factories:load_active_bundle_and_dependencies"
             ),
             "ping_convention = microcosm_sagemaker.conventions.ping:configure_ping",
+            "sagemaker_health_convention = microcosm_sagemaker.conventions.health:configure_health",
             "random = microcosm_sagemaker.random:Random",
             "sagemaker = microcosm_sagemaker.factories:configure_sagemaker",
             "sagemaker_metrics = microcosm_sagemaker.metrics.store:SageMakerMetrics",


### PR DESCRIPTION
https://globality.atlassian.net/browse/DEVOPS-353

microcosm-sagemaker is currently using /ping as the health check since this is what SageMaker serve convention is expecting.

Our ECS conventions says that every service health is checked with /api/health and not /ping. We don’t want to hack the health check to go to /ping since our values are that all services should look the same.

All that being said, we want to add /api/health support to microcosm-sagemaker, that should live side-by-side with the /ping until we deprecate serving with SageMaker.