### PR TITLE
Bump microcosm-flask to get marshmallow>=3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "boto3>=1.9.90",
         "click>=7.0",
         "microcosm>=2.12.0",
-        "microcosm_flask[metrics,spooky]>=1.28.0",
+        "microcosm-flask[metrics]>=2.0.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
This PR is the first step towards making sure that all our ML repos support `marshmallow>=3.0.0`