### PR TITLE
Fix Allennlp move operation

### DIFF
--- a/microcosm_sagemaker/frameworks/allennlp/bundle.py
+++ b/microcosm_sagemaker/frameworks/allennlp/bundle.py
@@ -45,6 +45,10 @@ class AllenNLPBundle(Bundle):
         allen_nlp_path.mkdir(parents=True)
 
         for child in self.temporary_allennlp_path.iterdir():
+            # NB: It is important to use `shutil.move` here rather than
+            # `rename` because the latter works across filesystems, and
+            # SageMaker uses a different filesystem for its temporary
+            # directories and the output artifact directory
             shutil.move(child, allen_nlp_path / child.name)
 
         self.temporary_allennlp_dir.cleanup()

--- a/microcosm_sagemaker/frameworks/allennlp/bundle.py
+++ b/microcosm_sagemaker/frameworks/allennlp/bundle.py
@@ -46,7 +46,7 @@ class AllenNLPBundle(Bundle):
 
         for child in self.temporary_allennlp_path.iterdir():
             # NB: It is important to use `shutil.move` here rather than
-            # `rename` because the latter works across filesystems, and
+            # `rename` because the former works across filesystems, and
             # SageMaker uses a different filesystem for its temporary
             # directories and the output artifact directory
             shutil.move(child, allen_nlp_path / child.name)

--- a/microcosm_sagemaker/frameworks/allennlp/bundle.py
+++ b/microcosm_sagemaker/frameworks/allennlp/bundle.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict
@@ -44,7 +45,7 @@ class AllenNLPBundle(Bundle):
         allen_nlp_path.mkdir(parents=True)
 
         for child in self.temporary_allennlp_path.iterdir():
-            child.rename(allen_nlp_path / child.name)
+            shutil.move(child, allen_nlp_path / child.name)
 
         self.temporary_allennlp_dir.cleanup()
 


### PR DESCRIPTION
The allennlp copy operation was failing in SageMaker due to the fact that the tmp directory is in a different filesystem than the output artifact directory