### PR TITLE
GLOB-38269 Add awscli dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     keywords="microcosm",
     install_requires=[
         "boto3>=1.9.90",
+        "awscli>=1.16.200",
         "click>=7.0",
         "microcosm>=2.12.0",
         "microcosm-flask[metrics]>=2.0.0",


### PR DESCRIPTION
Add `awscli` as a dependency since ML models due require it to download artifacts from `S3` into the container

https://globality.atlassian.net/browse/GLOB-38269