### PR TITLE
remove pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ setup(
         "awscli>=1.16.200",
         "click>=7.0",
         "microcosm>=2.12.0",
-        "microcosm-flask[metrics]>=2.8.0",
-        "python-dateutil<2.8.1",  # TODO: remove when botocore dependency failure is resolved.
+        "microcosm-flask[metrics]>=2.8.0",        
+        # See: https://github.com/boto/botocore/pull/1910
+        "python-dateutil<3.0.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
as upstream botocore no longer requires it. left a comment on the high-level pin still in place to tie back to the original botocore pinning so we can revisit again in the future as needed.