### PR TITLE
Add flag to disable threading locally

### DIFF
--- a/microcosm_sagemaker/commands/runserver.py
+++ b/microcosm_sagemaker/commands/runserver.py
@@ -61,5 +61,5 @@ def run_serve(
     graph.flask.run(
         host=host,
         port=port or graph.config.flask.port,
-        threading=threading,
+        threaded=threading,
     )

--- a/microcosm_sagemaker/commands/runserver.py
+++ b/microcosm_sagemaker/commands/runserver.py
@@ -28,8 +28,12 @@ from microcosm_sagemaker.profiling import enable_profiling
     "--profile/--no-profile",
     default=False,
 )
+@option(
+    "--threading/--no-threading",
+    default=True,
+)
 @input_artifact_option()
-def main(host, port, debug, profile, input_artifact):
+def main(host, port, debug, profile, input_artifact, threading):
     graph = create_serve_app(
         debug=debug,
         extra_loader=load_from_dict(
@@ -44,6 +48,7 @@ def main(host, port, debug, profile, input_artifact):
         graph=graph,
         host=host,
         port=port,
+        threading=threading,
     )
 
 
@@ -51,8 +56,10 @@ def run_serve(
     graph: ObjectGraph,
     host: str,
     port: int,
+    threading: bool,
 ) -> None:
     graph.flask.run(
         host=host,
         port=port or graph.config.flask.port,
+        threading=threading,
     )


### PR DESCRIPTION
`globality-taxonomies` doesn't have support for local multi-threaded flask serving, since you can't re-use taxonomy entities on other threads once spawned on the master.  Here we add a CLI flag to `runserver` to control whether it launches flask in single threaded or multi-threaded mode.