### PR TITLE
Add wandb run url to model landing pages

### DIFF
--- a/microcosm_sagemaker/metrics/wandb/store.py
+++ b/microcosm_sagemaker/metrics/wandb/store.py
@@ -64,6 +64,12 @@ class WeightsAndBiases:
         # Injecting the wandb run path into the config
         self.graph.config.wandb.run_path = wandb_run.path
 
+        # Adding the link to the Weights & Biases run to the landing page
+        # https://github.com/globality-corp/microcosm-flask/blob/develop/microcosm_flask/conventions/landing.py#L68
+        landing_convention_links = self.graph.config.landing_convention.get("links", {})
+        landing_convention_links.update({"Weights & Biases": wandb_run.get_url()})
+        self.graph.config.landing_convention.update({"links": landing_convention_links})
+
         self.logger.info(f"A new `weights & biases` run was created: {wandb_run.path}")
 
         return wandb_run


### PR DESCRIPTION
Adds the run url to the `landing_conventions` links and it will automatically show up in the landing page under _links_.