### PR TITLE
Import wandb in try/except

### DIFF
--- a/microcosm_sagemaker/metrics/wandb/store.py
+++ b/microcosm_sagemaker/metrics/wandb/store.py
@@ -3,11 +3,11 @@ import os
 from microcosm_logging.decorators import logger
 
 from microcosm_sagemaker.decorators import metrics_observer, training_initializer
-from wandb.apis import CommError
 
 
 try:
     import wandb
+    from wandb.apis import CommError
 except ImportError:
     pass
 


### PR DESCRIPTION
All `wandb` imports should be within a `try`/`except pass`. Otherwise, any `microcosm-sagemaker` user that does not use `wandb` will crash trying to import `wandb` which is not installed in the env. 

Here is an example: https://app.circleci.com/pipelines/github/globality-corp/experimental-matcher/601/workflows/4729be35-9756-45a9-9dfc-ea3918060a3d/jobs/3102/steps