### PR TITLE
GLOB-52695: Make step param optional for wandb.

### DIFF
--- a/microcosm_sagemaker/metrics/wandb/store.py
+++ b/microcosm_sagemaker/metrics/wandb/store.py
@@ -89,11 +89,8 @@ class WeightsAndBiases:
         return wandb_run
 
     def log_timeseries(self, **kwargs):
-        if "steps" in kwargs:
-            step = kwargs.pop("step")
-            self.wandb_run.log(kwargs, step=step)
-        else:
-            self.wandb_run.log(kwargs)
+        step = kwargs.pop("step", None)
+        self.wandb_run.log(kwargs, step=step)
         return None
 
     def log_static(self, **kwargs):

--- a/microcosm_sagemaker/metrics/wandb/store.py
+++ b/microcosm_sagemaker/metrics/wandb/store.py
@@ -89,8 +89,11 @@ class WeightsAndBiases:
         return wandb_run
 
     def log_timeseries(self, **kwargs):
-        step = kwargs.pop("step")
-        self.wandb_run.log(kwargs, step=step)
+        if "steps" in kwargs:
+            step = kwargs.pop("step")
+            self.wandb_run.log(kwargs, step=step)
+        else:
+            self.wandb_run.log(kwargs)
         return None
 
     def log_static(self, **kwargs):


### PR DESCRIPTION
In experimental matcher, we are logging some charts at various time steps during evaluation. These changes allow us to not worry about setting the step parameter during logging. 